### PR TITLE
add metrics-mvp link and update tryn-api docs link

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,18 @@
   <section id="about" class="about">
     <div class="container text-center">
       <h2>Our goal is to empower riders and advocates to improve transit.</h2>
-      <p class="lead">Take a look at our <a href="http://opentransit-map.s3-website-us-west-2.amazonaws.com" target="_blank">web app</a> and <a href="https://github.com/trynmaps/opentransit-api-docs/wiki/Getting-Started" target="_blank">API</a>.</p> 
+      <p class="lead">Take a look at our <a 
+        href="http://opentransit.herokuapp.com" target="_blank">
+        Metrics App,
+      </a>
+      <a
+        href="http://opentransit-map.s3-website-us-west-2.amazonaws.com" target="_blank">
+        Vehicles Map,
+      </a>
+      </a> and <a
+        href="https://github.com/trynmaps/tryn-api/wiki/Getting-Started" target="_blank">
+        Vehicle Locations API.
+      </a></p> 
     </div>
     <!-- /.container -->
   </section>


### PR DESCRIPTION
- link to the ongoing Metrics MVP project on the homepage
- looks the same except for:
<img width="1509" alt="Screen Shot 2019-06-05 at 11 37 17 PM" src="https://user-images.githubusercontent.com/8988797/59005308-ee341b00-87ea-11e9-8649-2d7ee2fd07f8.png">
